### PR TITLE
Allow user defined PREFERRED_CHAIN #1

### DIFF
--- a/templates/config.j2
+++ b/templates/config.j2
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # Copyright 2021 Joyent, Inc.
+# Copyright 2024 MNX Cloud, Inc.
 
 KEY_ALGO={{ __letsencrypt.key_algo }}
 CERTDIR=/opt/ssl
@@ -13,3 +14,8 @@ CONTACT_EMAIL={{ __letsencrypt.contact }}
 OWNER={{ __letsencrypt.owner }}
 SERVICES=( {{ __letsencrypt.restart_services | join(' ') }} )
 WELLKNOWN={{ __letsencrypt.well_known }}
+case $CA in
+    $prod_ca) PREFERRED_CHAIN='ISRG Root X1' ;;
+    $staging_ca) PREFERRED_CHAIN='(STAGING) Pretend Pear X1' ;;
+    *) PREFERRED_CHAIN={{ __letsencrypt.preferred_chain|default('') }} ;;
+esac


### PR DESCRIPTION
We set this variable in https://github.com/TritonDataCenter/triton-dehydrated/blob/c6a5a2245a40c2465280776a5e0af2de671864cd/config#L95 since https://github.com/TritonDataCenter/triton-dehydrated/commit/a9510f61412b118009c2fc16f96c3ecd94b9501d.

This is useful for the Let's Encrypt staging CA, which needs this variable set to `(STAGING) Pretend Pear X1`.

Fixes #1.

EDIT: An alternative might be to remove `PREFERRED_CHAIN` from triton-dehydrated's `config`, since it seems to be [the LE default chain](https://letsencrypt.org/certificates/#chains) now?